### PR TITLE
fix: Disable pin request for gpg signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Fixed
+- gpg signing failing in ci jobs, due to interactive pin requests

--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,13 @@
                         <goals>
                             <goal>sign</goal>
                         </goals>
+                        <configuration>
+                          <!-- Needed for ci, otherwise gpg will request for pin in a non interactive session -->
+                          <gpgArguments>
+                            <arg>--pinentry-mode</arg>
+                            <arg>loopback</arg>
+                          </gpgArguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Updated configuration for gpg signing plugin, to read the gpg passphrase properly from maven settings. [more Information](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#extra-setup-for-pomxml)